### PR TITLE
Added support timezones and languages

### DIFF
--- a/wp-flipclock/inc/display.php
+++ b/wp-flipclock/inc/display.php
@@ -1,8 +1,23 @@
 <?php
+/* FUNCTION FOR GETTING TIMEZONE OFFSET */
+function get_timezone_offset($timezone="UTC"){
+ if($timezone=="UTC"){
+	return 0;
+ } else {
+	$dateTimeOfZone = new DateTimeZone($timezone);
+	$dateTimeInZone = new DateTime("now", $dateTimeOfZone);
+	$dateTimeOfUTC = new DateTimeZone("UTC");
+	$dateTimeInUTC = new DateTime("now", $dateTimeOfUTC);
+	return 1000*($dateTimeOfUTC->getOffset($dateTimeInUTC)-$dateTimeOfZone->getOffset($dateTimeInZone));	
+ }
+}
 
 /** FUNCTION FOR DISPLAYING THE CLOCK **/
-function wp_flipclock_display_clock($name, $countdown = "", $datestring = "", $clockface = "hours")
+function wp_flipclock_display_clock($name, $countdown = "", $datestring = "", $clockface = "hours", $lang="english", $timezone="UTC", $seconds=1)
 {
+
+
+
 	$clock_string = "";
 	$clock_string .= '<div class="'.$name.'"></div>';
 
@@ -13,18 +28,18 @@ function wp_flipclock_display_clock($name, $countdown = "", $datestring = "", $c
 
 	if ($datestring && $countdown) {
 
-		$phptime = strtotime($datestring);
-		$clock_js_string .= 'var currentDate'.$name.' = new Date();';
-		$clock_js_string .= 'var futureDate'.$name.'  = new Date('.$phptime.' * 1000);';
+		$timeOffset = get_timezone_offset($timezone);
+		$clock_js_string .= "var currentDate = new Date().getTime() + new Date().getTimezoneOffset()*60000 - $timeOffset;";
+		$clock_js_string .= "var futureDate  = Date.parse('$datestring');";
 
-		$clock_js_string .= 'var diff'.$name.' = futureDate'.$name.'.getTime() / 1000 - currentDate'.$name.'.getTime() / 1000;';
+		$clock_js_string .= 'var diff = futureDate / 1000 - currentDate / 1000;';
 
 	} elseif ($datestring && !$countdown) {
 
-		$phptime = strtotime($datestring);
-		$clock_js_string .= 'var currentDate'.$name.' = new Date();';
-		$clock_js_string .= 'var pastDate'.$name.'  = new Date('.$phptime.' * 1000);';
-		$clock_js_string .= 'var diff'.$name.' = currentDate'.$name.'.getTime() / 1000 - pastDate'.$name.'.getTime() / 1000;';
+		$timeOffset = get_timezone_offset($timezone);
+		$clock_js_string .= "var currentDate = new Date().getTime() + new Date().getTimezoneOffset()*60000 - $timeOffset;";
+		$clock_js_string .= "var pastDate  = Date.parse('$datestring');";
+		$clock_js_string .= 'var diff = currentDate / 1000 - pastDate / 1000;';
 
 	}
 			
@@ -34,10 +49,17 @@ function wp_flipclock_display_clock($name, $countdown = "", $datestring = "", $c
 		clock = jQuery('.".$name."').FlipClock(";
 
 	if ($datestring) {
-		$clock_js_string .= "diff".$name.", {";
+		$clock_js_string .= "diff, {";
 	} else {
 		$clock_js_string .= "{";
 	} 
+
+	if ($lang)
+	{
+
+		$clock_js_string .= "language: '".$lang."', ";
+
+	}
 	
 	if ($countdown)
 	{
@@ -46,12 +68,14 @@ function wp_flipclock_display_clock($name, $countdown = "", $datestring = "", $c
 
 	}
 
+
 	if ($countdown && $clockface && $clockface != "hours") {
 		$clock_js_string .= ", ";
 	}
 
 	switch ($clockface) {
 		case "days":
+			if(!$seconds) $clock_js_string .= "showSeconds: false, ";
 			$clock_js_string .= "clockFace: 'DailyCounter'";
 			break;
 		case "minutes":
@@ -83,9 +107,12 @@ function wp_flipclock_shortcode($atts)
 	      'name' => 'wpflipclock',
 	      'countdown' => '',
 	      'date' => '',
-	      'face' => 'hours'
+	      'lang' => 'english',
+	      'timezone' => 'UTC',
+	      'face' => 'hours',
+	      'seconds' => '1'
      ), $atts ) );
-    return wp_flipclock_display_clock($name, $countdown, $date, strtolower($face));
+    return wp_flipclock_display_clock($name, $countdown, $date, strtolower($face), $lang, $timezone, intval($seconds));
 }
 
 add_shortcode('flipclock','wp_flipclock_shortcode');


### PR DESCRIPTION
1. Use "lang=" (optional) to change language of labels (days,hours,minutes,seconds). Supported languages: English, Russian, Spanish, French, German.
2. Use "timezone=" (optional) to set timezone for date. Now it shows the correct time before the event. (fix issue #2 Time Localisation). The time zones have unique names in the form "Area/Location", e.g. "America/New_York".
3. Use "seconds=" (optional) to hide|show seconds in face-mode "days". Supported values: 1 - shows seconds, 0 - hide seconds.

Example:

[flipclock countdown="true" face="days" date="2015-02-21 10:00:00" seconds=0 timezone="Europe/Moscow" lang="russian"]
Shows countdown to date "21 Feb 2015 10:00am GMT+0300" with russian labels and seconds will be hidden.