### PR TITLE
This is a great plugin. I did notice that the time is out by 10 hrs

### DIFF
--- a/wp-flipclock/inc/display.php
+++ b/wp-flipclock/inc/display.php
@@ -34,7 +34,7 @@ function wp_flipclock_display_clock($name, $countdown = "", $datestring = "", $c
 	if ($datestring && $countdown) {
 
 		$timeOffset = wp_flipclock_get_timezone_offset($timezone);
-		$clock_js_string .= "var currentDate".$name." = new Date().getTime() + new Date().getTimezoneOffset()*60000 - ". $timeOffset .";";
+		$clock_js_string .= "var currentDate".$name." = new Date().getTime() + new Date().getTimezoneOffset()*0 - ". $timeOffset .";";
 		$clock_js_string .= "var futureDate".$name."  = Date.parse('".$javascripttime."');";
 
 		$clock_js_string .= 'var diff'.$name.' = futureDate'.$name.' / 1000 - currentDate'.$name.' / 1000;';


### PR DESCRIPTION
(adding additional 10 hrs), regardless of timezone, or if left at UTC,
when specifying a date & time to count down in the shortcake (e.g.
date="2015-03-31 18:00:00”).

I seem to have fixed this by editing line 37 of display.php to
$clock_js_string .= "var currentDate".$name." = new Date().getTime() +
new Date().getTimezoneOffset()*0 - ". $timeOffset .";";

(I changed “getTimezoneOffset()*60000” to “getTimezoneOffset()*0”)

This seemed to fix it for me, however, I not overly experienced, so not
sure if what I’ve done is best practice. I thought I’d fork it and add
this for you to look at.